### PR TITLE
Fixed org.godotengine.godot.Godot cannot be cast to android.app.Activity

### DIFF
--- a/android-plugin/src/main/java/ru/mobilap/tenjin/Tenjin.java
+++ b/android-plugin/src/main/java/ru/mobilap/tenjin/Tenjin.java
@@ -28,7 +28,7 @@ public class Tenjin extends GodotPlugin
     public Tenjin(Godot godot) 
     {
         super(godot);
-        activity = godot;
+        activity = godot.getActivity();
     }
 
     @Override


### PR DESCRIPTION
Hi again. Thanks for nativelib and the plugins!

In Godot 3.3, the plugin would cause  `org.godotengine.godot.Godot cannot be cast to android.app.Activity` when enabled and start running on Android, then result in a crash.

So here's a tiny fix probably related to https://github.com/godotengine/godot/issues/47198

